### PR TITLE
Automate organization mirror sync

### DIFF
--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,21 @@
+name: Sync upstream mirror
+
+on:
+  schedule:
+    - cron: "7,22,37,52 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: github.repository == 'alpaca-engineering/tinyTouch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fast-forward main from the personal repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --method POST "repos/$GITHUB_REPOSITORY/merge-upstream" \
+            -f branch=main


### PR DESCRIPTION
Add an organization-fork-only workflow that fast-forwards alpaca-engineering/tinyTouch from the personal source repository every 15 minutes. The job is skipped in the source repository, and firmware workflows remain disabled in the organization fork.