### PR TITLE
Make interrupted updates retryable

### DIFF
--- a/firmware/tiny_touch_unified/main/config_console.c
+++ b/firmware/tiny_touch_unified/main/config_console.c
@@ -326,7 +326,9 @@ static void handle_command(void) {
   else if (strcmp(command, "RESET FACTORY") == 0) factory_reset();
   else if (strncmp(command, "OTA BEGIN ", 10) == 0) ota_begin(command + 10);
   else if (strncmp(command, "OTA WRITE ", 10) == 0) ota_write(command + 10);
-  else if (strncmp(command, "OTA ABORT ", 10) == 0 && token_matches(command + 10)) {
+  else if (strcmp(command, "OTA ABORT") == 0) {
+    firmware_update_abort(); clear_ota(); reply("OK OTA ABORT");
+  } else if (strncmp(command, "OTA ABORT ", 10) == 0 && token_matches(command + 10)) {
     firmware_update_abort(); clear_ota(); reply("OK OTA ABORT");
   } else if (strncmp(command, "OTA COMMIT ", 11) == 0) ota_commit(command + 11);
   else reply("ERR COMMAND");

--- a/tests/test_protocol6_firmware.py
+++ b/tests/test_protocol6_firmware.py
@@ -44,6 +44,7 @@ class ProtocolSixFirmwareTests(unittest.TestCase):
         self.assertIn("OK OTA STAGED power_cycle=required", console)
         self.assertIn("esp_ota_set_boot_partition", update)
         self.assertIn("firmware_update_staged", update)
+        self.assertIn('strcmp(command, "OTA ABORT") == 0', console)
         self.assertNotIn("fingerprint_prepare_for_restart", console)
 
     def test_piv_create_is_live_and_status_reports_readiness(self) -> None:

--- a/tests/test_tinytouch_cli.py
+++ b/tests/test_tinytouch_cli.py
@@ -223,13 +223,60 @@ class ProtocolSixTests(unittest.TestCase):
         digest = hashlib.sha256(image).hexdigest()
         with (
             mock.patch.object(serial, "Serial", FakeSerial),
-            mock.patch.object(cli, "serial_command", return_value=["OK AUTH"]),
+            mock.patch.object(cli, "serial_command", return_value=["OK"]) as command,
             mock.patch.object(cli, "unload_helper", return_value=False),
         ):
             cli.stage_ota("/dev/cu.TT-1234", image, digest)
+        self.assertEqual(command.call_args_list[0].args, ("/dev/cu.TT-1234", "OTA ABORT"))
+        self.assertEqual(command.call_args_list[1].args, ("/dev/cu.TT-1234", "AUTH"))
         self.assertTrue(writes[0].startswith("OTA BEGIN "))
         self.assertTrue(writes[-1].startswith("OTA COMMIT "))
         self.assertNotIn("RESET", " ".join(writes))
+
+    def test_interrupted_ota_aborts_its_session(self):
+        try:
+            import serial  # type: ignore
+        except ImportError:
+            self.skipTest("pyserial is not installed")
+
+        writes = []
+
+        class InterruptedSerial:
+            def __init__(self, *_args, **_kwargs):
+                self.responses = []
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def write(self, payload):
+                command = payload.decode("ascii").strip()
+                writes.append(command)
+                if command.startswith("OTA BEGIN "):
+                    self.responses.append(b"OK OTA BEGIN next=0\n")
+                elif command.startswith("OTA WRITE "):
+                    raise KeyboardInterrupt
+                elif command.startswith("OTA ABORT "):
+                    self.responses.append(b"OK OTA ABORT\n")
+
+            def flush(self):
+                pass
+
+            def readline(self):
+                return self.responses.pop(0) if self.responses else b""
+
+        image = bytes(range(64))
+        digest = hashlib.sha256(image).hexdigest()
+        with (
+            mock.patch.object(serial, "Serial", InterruptedSerial),
+            mock.patch.object(cli, "serial_command", return_value=["OK"]),
+            mock.patch.object(cli, "unload_helper", return_value=False),
+            self.assertRaises(KeyboardInterrupt),
+        ):
+            cli.stage_ota("/dev/cu.TT-1234", image, digest)
+        self.assertTrue(writes[-1].startswith("OTA ABORT "))
 
     def test_rom_flow_only_prompts_for_a_physical_reconnect(self):
         args = SimpleNamespace(port=None)

--- a/tinytouch
+++ b/tinytouch
@@ -895,19 +895,34 @@ def stage_ota(port: str, image: bytes, digest: str) -> None:
         import serial  # type: ignore
     except ImportError as exc:
         raise ToolError("pyserial is required for OTA.") from exc
+    # An interrupted older client may have left an incomplete upload active.
+    # Aborting is safe because committed firmware is already in another slot.
+    try:
+        serial_command(port, "OTA ABORT", timeout=2)
+    except (ToolError, SerialTimeout):
+        # Firmware before 0.1.1 does not support an unscoped abort.
+        pass
+    say("Wait for the prompt before touching the fingerprint sensor.")
     serial_command(port, "AUTH", timeout=15)
     token = secrets.token_hex(16)
     was_loaded = unload_helper()
     try:
         with serial.Serial(port, 115200, timeout=0.25, write_timeout=5) as device:
-            lines = serial_exchange(device, f"OTA BEGIN {token} {len(image)} {digest}")
-            offset = response_next(lines, "OTA")
-            for start in range(offset, len(image), 360):
-                payload = base64.b64encode(image[start:start + 360]).decode()
-                command = f"OTA WRITE {token} {start} {payload}"
-                lines = serial_exchange(device, command)
+            try:
+                lines = serial_exchange(device, f"OTA BEGIN {token} {len(image)} {digest}")
                 offset = response_next(lines, "OTA")
-            commit = serial_exchange(device, f"OTA COMMIT {token}", timeout=10)
+                for start in range(offset, len(image), 360):
+                    payload = base64.b64encode(image[start:start + 360]).decode()
+                    command = f"OTA WRITE {token} {start} {payload}"
+                    lines = serial_exchange(device, command)
+                    offset = response_next(lines, "OTA")
+                commit = serial_exchange(device, f"OTA COMMIT {token}", timeout=10)
+            except BaseException:
+                try:
+                    serial_exchange(device, f"OTA ABORT {token}", timeout=2)
+                except (ToolError, SerialTimeout):
+                    pass
+                raise
     finally:
         if was_loaded:
             load_helper()


### PR DESCRIPTION
Clear abandoned OTA sessions before an update, abort the active session when the CLI is interrupted, and make the fingerprint timing explicit. Includes firmware support for safe unscoped cancellation.\n\nValidation: 67 local tests passed.