### PR TITLE
Show OTA upload progress

### DIFF
--- a/tests/test_tinytouch_cli.py
+++ b/tests/test_tinytouch_cli.py
@@ -225,6 +225,7 @@ class ProtocolSixTests(unittest.TestCase):
             mock.patch.object(serial, "Serial", FakeSerial),
             mock.patch.object(cli, "serial_command", return_value=["OK"]) as command,
             mock.patch.object(cli, "unload_helper", return_value=False),
+            mock.patch.object(cli, "say") as say,
         ):
             cli.stage_ota("/dev/cu.TT-1234", image, digest)
         self.assertEqual(command.call_args_list[0].args, ("/dev/cu.TT-1234", "OTA ABORT"))
@@ -232,6 +233,10 @@ class ProtocolSixTests(unittest.TestCase):
         self.assertTrue(writes[0].startswith("OTA BEGIN "))
         self.assertTrue(writes[-1].startswith("OTA COMMIT "))
         self.assertNotIn("RESET", " ".join(writes))
+        output = [call.args[0] for call in say.call_args_list]
+        self.assertIn("Uploading firmware: 0%", output)
+        self.assertIn("Uploading firmware: 100%", output)
+        self.assertIn("Verifying firmware...", output)
 
     def test_interrupted_ota_aborts_its_session(self):
         try:

--- a/tinytouch
+++ b/tinytouch
@@ -911,11 +911,18 @@ def stage_ota(port: str, image: bytes, digest: str) -> None:
             try:
                 lines = serial_exchange(device, f"OTA BEGIN {token} {len(image)} {digest}")
                 offset = response_next(lines, "OTA")
+                say("Uploading firmware: 0%")
+                next_progress = 10
                 for start in range(offset, len(image), 360):
                     payload = base64.b64encode(image[start:start + 360]).decode()
                     command = f"OTA WRITE {token} {start} {payload}"
                     lines = serial_exchange(device, command)
                     offset = response_next(lines, "OTA")
+                    progress = min(100, offset * 100 // len(image))
+                    if progress >= next_progress:
+                        say(f"Uploading firmware: {progress}%")
+                        next_progress = progress + 10
+                say("Verifying firmware...")
                 commit = serial_exchange(device, f"OTA COMMIT {token}", timeout=10)
             except BaseException:
                 try:


### PR DESCRIPTION
Show visible upload percentages and firmware verification after fingerprint authorization so a normal OTA transfer does not appear hung.\n\nValidation: focused CLI and firmware tests passed.