### PR TITLE
Clarify CLI password prompts and streamline fingerprint enrollment

### DIFF
--- a/tinytouch
+++ b/tinytouch
@@ -79,6 +79,28 @@ def verbose(message: str) -> None:
         say(f"[verbose] {message}")
 
 
+SOUND_DIR = Path("/System/Library/Sounds")
+TOUCH_SOUND = "Tink"
+LIFT_SOUND = "Pop"
+DONE_SOUND = "Glass"
+
+
+def chime(name: str) -> None:
+    """Play a macOS system sound as non-blocking feedback. Never fails loudly."""
+    if sys.platform != "darwin" or os.environ.get("TINYTOUCH_NO_SOUND"):
+        return
+    sound = SOUND_DIR / f"{name}.aiff"
+    if not sound.exists():
+        return
+    try:
+        subprocess.Popen(
+            ["afplay", str(sound)],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        verbose(f"sound unavailable: {name}")
+
+
 def run(command: list[str], **kwargs):
     verbose("run: " + " ".join(command))
     try:
@@ -100,8 +122,11 @@ def authorize_macos() -> None:
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
     )
     if cached.returncode:
-        say("Authorize macOS in this terminal.")
-        validated = subprocess.run(["sudo", "-v"], check=False)
+        say()
+        say("macOS needs to authorize this step. Your password is not saved.")
+        say("Enter your Mac login password. Nothing appears as you type \u2014 that is normal.")
+        validated = subprocess.run(["sudo", "-v", "-p", "Mac password: "], check=False)
+        say()
         if validated.returncode:
             raise ToolError("macOS authorization failed.")
     _sudo_session_ready = True
@@ -110,7 +135,10 @@ def authorize_macos() -> None:
 def prepare_hid_password() -> None:
     """Capture the HID password and unlock Keychain without requiring sudo."""
     global _setup_password
+    say()
+    say("Enter your Mac login password. Nothing appears as you type \u2014 that is normal.")
     entered = bytearray(getpass.getpass("Mac password: ").encode("utf-8"))
+    say()
     if not entered:
         raise ToolError("A Mac password is required for HID mode.")
     try:
@@ -373,12 +401,15 @@ def exchange_serial(device, command: str, *, timeout: float) -> list[str]:
         lines.append(line)
         verbose("device: " + line)
         if line == "EVENT TOUCH" and not touch_prompted:
-            say("Touch the fingerprint sensor now.")
+            chime(TOUCH_SOUND)
+            say("   touch the sensor")
             touch_prompted = True
         elif line == "EVENT LIFT":
-            say("Lift your finger from the sensor.")
+            chime(LIFT_SOUND)
+            say("   lift your finger")
         elif line == "EVENT TOUCH_AGAIN":
-            say("Touch the same finger again now.")
+            chime(TOUCH_SOUND)
+            say("   touch again")
         if is_terminal(command, line):
             break
     if not lines or not is_terminal(command, lines[-1]):
@@ -552,6 +583,7 @@ def password_for(account: str) -> str:
     global _setup_password
     say("HID mode types this password after a fingerprint match.")
     say("It is stored in this Mac user's Keychain for this device.")
+    say()
     if _setup_password is not None:
         try:
             value = _setup_password.decode("utf-8")
@@ -562,8 +594,10 @@ def password_for(account: str) -> str:
         finally:
             _setup_password[:] = b"\x00" * len(_setup_password)
             _setup_password = None
+    say("Nothing appears as you type \u2014 that is normal.")
     first = getpass.getpass("Password: ")
     second = getpass.getpass("Password again: ")
+    say()
     if not first or first != second:
         raise ToolError("Passwords must be non-empty and match.")
     if len(first.encode()) > 160:
@@ -691,9 +725,16 @@ def enroll(port: str, skip: bool) -> None:
         if ask("Replace the existing fingerprint enrollment? [y/N] ").lower() not in {"y", "yes"}:
             raise ToolError("Fingerprint enrollment was not changed.")
     unlock(port)
+    say()
+    say("Enrolling your fingerprint. Use the same finger for all four scans.")
     for slot in range(1, 5):
-        say(f"Touch the sensor for view {slot} of 4.")
+        say()
+        say(f"Scan {slot} of 4")
         serial_command(port, f"FINGER ENROLL {slot}", timeout=45)
+    chime(DONE_SOUND)
+    say()
+    say("Fingerprint enrolled.")
+    say()
     current = status(port)
     if current.get("fingerprints") != "4":
         raise ToolError("Live verification failed: the four-view fingerprint profile was not reported.")


### PR DESCRIPTION
## What changed

CLI-only UX changes in `tinytouch`. No protocol, firmware, or Keychain behavior is affected.

**Password prompts**
- Every password prompt now says `Nothing appears as you type — that is normal.` Applies to the HID Keychain capture, the HID re-entry path, and the PIV `sudo` authorization.
- The PIV path previously fell through to sudo's bare `Password:`. It now uses `sudo -v -p "Mac password: "` so both modes read identically, preceded by a short `macOS needs to authorize this step. Your password is not saved.` — the honest contrast with HID, where the password *is* stored in the Keychain.

**Enrollment**
- Replaced the four full sentences per scan with a `Scan N of 4` header and indented `touch the sensor` / `lift your finger` / `touch again` steps, with blank lines between scans.
- Added a closing `Fingerprint enrolled.` line.

**Audio feedback**
- New `chime()` helper plays macOS system sounds during enrollment: `Tink` on each touch prompt, `Pop` on lift, `Glass` once all four scans complete.
- Non-blocking (`afplay` via `Popen`), and silently no-ops off macOS, when the sound file is missing, or when `TINYTOUCH_NO_SOUND` is set.

## Why

Setup reads as intimidating to users who aren't comfortable in a terminal. Hidden password input looks like a frozen prompt, and the dense enrollment output gave no sense of progress or separation between scans. The sounds give confirmation without making the user watch the terminal while positioning a finger.

## Before / after

```
Mac password:                              Enter your Mac login password. Nothing
Touch the sensor for view 1 of 4.          appears as you type — that is normal.
Touch the fingerprint sensor now.          Mac password:
Lift your finger from the sensor.
Touch the same finger again now.           Scan 1 of 4
Touch the sensor for view 2 of 4.             touch the sensor
...                                           lift your finger
                                              touch again
```

## Notes for reviewers

- Both modes share `enroll()` and `exchange_serial()`, so the scan formatting and sounds apply to HID and PIV alike. The sounds also fire on other touch-driven commands such as `AUTH` — intentional, for consistency.
- `sudo -p` only affects the first prompt; on a wrong password sudo re-prompts with its own text.
- Verified: the file parses, `python -m unittest discover -s tests` passes, and the flow was exercised on real hardware in both HID and PIV mode. Sound choices are easy to swap if `Tink`/`Pop` aren't the right feel.
- Running from source needs Python 3.10+ (`tinytouch_keychain.py` uses `X | None` annotations without `from __future__ import annotations`); macOS system Python 3.9 fails on import. Pre-existing, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)