### PR TITLE
Restore the Alpaca CLI header

### DIFF
--- a/tests/test_tinytouch_cli.py
+++ b/tests/test_tinytouch_cli.py
@@ -338,6 +338,10 @@ class ProtocolSixTests(unittest.TestCase):
             "tinyTouch is ready in PIV mode.",
             [call.args[0] for call in output.call_args_list],
         )
+        self.assertIn(
+            "Setting up PIV certificates. This may take up to 30 seconds.",
+            [call.args[0] for call in output.call_args_list],
+        )
 
     def test_macos_authorization_explains_hidden_password_input(self):
         results = [SimpleNamespace(returncode=1), SimpleNamespace(returncode=0)]

--- a/tests/test_tinytouch_cli.py
+++ b/tests/test_tinytouch_cli.py
@@ -21,6 +21,25 @@ loader.exec_module(cli)
 
 
 class ProtocolSixTests(unittest.TestCase):
+    def test_startup_mark_shows_version_and_command_section(self):
+        with (
+            mock.patch.object(cli.sys.stdout, "isatty", return_value=True),
+            mock.patch.dict(cli.os.environ, {}, clear=True),
+            mock.patch.object(cli, "say") as output,
+        ):
+            cli.show_startup_mark("factory-reset")
+        text = "\n".join(call.args[0] for call in output.call_args_list)
+        self.assertIn("⣰⣷⣼⣇", text)
+        self.assertIn(cli.CLI_VERSION, text)
+        self.assertIn("Factory Reset", text)
+
+    def test_terminal_style_respects_no_color(self):
+        with (
+            mock.patch.object(cli.sys.stdout, "isatty", return_value=True),
+            mock.patch.dict(cli.os.environ, {"NO_COLOR": "1"}, clear=True),
+        ):
+            self.assertEqual(cli.terminal_style("Setup", "36"), "Setup")
+
     def test_mode_prompt_explains_hid_and_piv(self):
         with (
             mock.patch.object(cli, "say") as output,

--- a/tinytouch
+++ b/tinytouch
@@ -76,6 +76,40 @@ def say(message: str = "") -> None:
     print(message, flush=True)
 
 
+def terminal_style(text: str, code: str) -> str:
+    """Apply restrained terminal styling when the terminal supports it."""
+    if (
+        not sys.stdout.isatty()
+        or os.environ.get("NO_COLOR") is not None
+        or os.environ.get("TERM") == "dumb"
+    ):
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def show_startup_mark(command: str) -> None:
+    """Show the original Alpaca mark and one command section divider."""
+    if not sys.stdout.isatty():
+        return
+    mark = (
+        "⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣰⣷⣼⣇⡀⠀",
+        "⠀⠀⠀⠀⢀⣀⣀⡀⠀⠀⣿⣿⡟⠟⢡⡄",
+        "⠀⠀⠀⣤⣿⣯⣽⢿⣤⠀⣿⣿⣿⡟⠋⠀",
+        "⠀⣰⣟⡛⢛⡛⢛⣛⢛⣻⣿⣿⣿⡇⠀⠀",
+        "⠸⣿⣿⣷⣿⣿⣾⣿⣾⣿⣿⣿⣿⡇⠀⠀",
+        "⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⡿⠃⠀⠀",
+        "⠀⢸⣿⣿⣿⡿⠉⠉⣿⣿⡏⣿⠁⠀⠀⠀",
+        "⠀⠀⢸⡇⣿⡇⠀⠀⢸⣿⢸⡇⠀⠀⠀⠀",
+    )
+    for line in mark:
+        say(terminal_style(line, "36"))
+    say(f"          tinyTouch {terminal_style(CLI_VERSION, '2')}")
+    say("")
+    title = command.replace("-", " ").title()
+    say(terminal_style(f"── {title} ────────────────────", "2"))
+    say("")
+
+
 def verbose(message: str) -> None:
     if VERBOSE:
         say(f"[verbose] {message}")
@@ -1433,6 +1467,7 @@ def main() -> int:
         return 0
     args = parser().parse_args()
     VERBOSE = args.verbose
+    show_startup_mark(args.command)
     try:
         args.func(args)
     except KeyboardInterrupt:

--- a/tinytouch
+++ b/tinytouch
@@ -835,7 +835,7 @@ def command_setup(args: argparse.Namespace) -> None:
         else:
             if device.get("piv") != "ready":
                 say("")
-                say("Setting up PIV certificates. This may take a moment.")
+                say("Setting up PIV certificates. This may take up to 30 seconds.")
                 unlock(
                     port,
                     reason="create your PIV identity",


### PR DESCRIPTION
Restores the original Alpaca terminal mark, adds the CLI version and a restrained command divider, and starts PIV creation progress at the actual slow operation. Also shortens the OTA reconnect message.

Tests: `python3 -m unittest tests.test_tinytouch_cli`